### PR TITLE
Improve container handling and fix Nextclade compatibility issues

### DIFF
--- a/sbatch_clearlabs_report.sh
+++ b/sbatch_clearlabs_report.sh
@@ -13,5 +13,5 @@
 
 module load apptainer
 
-#Run script/command and use $SLURM_CPUS_ON_NODE
-python flaq_sc2_clearlabs.py --fastqs fastqs/ --assemblies assemblies/ --bams bams/ --threads $SLURM_CPUS_ON_NODE --sotc S:L452R,S:E484K --pango_path /blue/bphl-florida/share/singularity/pangolin_4.3.1-pdata-1.31.sif --pangolin v4.3.1 --pangolin_data v1.31
+#Run script/command and use $SLURM_CPUS_ON_NODE. Pangolin-related arguments/parameters are now optional. By default, the pipeline will now pull the latest pangolin and pangolin-data versions, as well as nextclade.
+python flaq_sc2_clearlabs.py --fastqs fastqs/ --assemblies assemblies/ --bams bams/ --threads $SLURM_CPUS_ON_NODE --sotc S:L452R,S:E484K


### PR DESCRIPTION
- Added automatic pulling and cleanup of Nextclade and Pangolin containers
- Extracted version info from containers for final reports
- Enabled automatic Nextclade dataset download with proper directory structure
- Made Pangolin CLI arguments optional for improved flexibility
- Fixed compatibility issue with newer Nextclade versions (e.g., removed --input-fasta)